### PR TITLE
Ajout d'un gestionnaire d'évènement manquant au scan

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -170,6 +170,10 @@ var app = new Vue({
                         Materialize.toast(data.message, 4000);
                     }
                 }.bind(this),
+                complete: function(xhr, code) {
+                    if (code == "error")
+                        Materialize.toast("Une erreur s'est produite", 4000);
+                },
                 error: function(xhr, status, err) {
                     Materialize.toast(err.toString(),4000);
                 }.bind(this)


### PR DESCRIPTION
Bonjour,

Ce pull request corrige un problème avec l'application lors du scan du QR code.

Côté esup-otp-api, si le *header* `X-Forwarded-Proto` n'est pas présent, le QR code à scanner est généré avec [une URL en `http`](https://github.com/EsupPortail/esup-otp-api/blob/cd9de6186c0a441191452b8915cf558d79f4b37c/methods/push.js#L136).

Si la redirection vers `https` est tout de même activée, une 302 est renvoyée. Or, pour la fonction `ajax` de jQuery, il ne s'agit ni d'un `success`, ni d'un `error`, donc aucun toast n'était affiché à l'écran. Le gestionnaire `complete` est cependant appelé dans tous les cas.

Bonne fin de journée.