### PR TITLE
Suppression de la taille fixe des éléments de la barre latérale

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -253,9 +253,7 @@ ul.collection {
         height: 44px;
         line-height: 44px;
  }
-ul#slide-out li {
-    width: 300px
-    }
+
 .side-nav.fixed a {
             display: block;
             padding: 0 12px 0 10px;


### PR DESCRIPTION
Bonjour,

Ce pull request corrige un problème d'affichage de la barre latérale lorsque l'on essaie de la faire glisser vers la gauche (constaté sur iPhone en tous cas) :

![](https://user-images.githubusercontent.com/108279419/232831568-a7a3188b-9b8a-4f0d-a64f-06d42d67d1a2.PNG)

Bonne fin de journée.